### PR TITLE
Pass options to BenchmarkSwitcher

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -12,6 +12,12 @@ namespace BenchmarkMockNet
         {
             new BenchmarkTests().RunAll();
 
+            if (args.Length == 0)
+            {
+                // With no options, run all benchmarks at default settings
+                args = new[] { "--filter", "*" };
+            }
+
             new BenchmarkSwitcher(new[] {
                 typeof(Construction),
                 typeof(Callback),
@@ -24,7 +30,7 @@ namespace BenchmarkMockNet
                 typeof(EmptyReturnOnly),
                 typeof(ReturnOnly),
                 typeof(VerifyOnly)
-            }).RunAll();
+            }).Run(args);
         }
     }
 }


### PR DESCRIPTION
Sorry for the PR out of the blue, but I was playing with BenchmarkMockNet and could not figure out how to easily run a subset of the tests. `BenchmarkSwitcher` allows one to filter the tests, but it wasn't being passed the command line arguments, so I figured "why not pass them along?".

I took the extra step of adding a default "--filter *" if no options were specified, to preserver the existing behaviour. I wasn't sure if that's important to you.

If there's anything I missed, such as updating documentation, or any change you'd like, no matter how small, please don't hesitate to mention it.